### PR TITLE
Fix Eigen3.4.0 compatibility issue by using integer indices

### DIFF
--- a/esvo_core/src/core/EventBM.cpp
+++ b/esvo_core/src/core/EventBM.cpp
@@ -91,7 +91,7 @@ bool esvo_core::core::EventBM::match_an_event(
      x_rect(1) < 0 || x_rect(1) > camSysPtr_->cam_left_ptr_->height_ - 1)
     return false;
   // This is to avoid depth estimation happening in the mask area.
-  if(camSysPtr_->cam_left_ptr_->UndistortRectify_mask_(x_rect(1), x_rect(0)) <= 125)
+  if(camSysPtr_->cam_left_ptr_->UndistortRectify_mask_(static_cast<int>(x_rect(1)), static_cast<int>(x_rect(0))) <= 125)
     return false;
   Eigen::Vector2i x1(std::floor(x_rect(0)), std::floor(x_rect(1)));
   Eigen::Vector2i x1_left_top;

--- a/esvo_core/src/core/RegProblemLM.cpp
+++ b/esvo_core/src/core/RegProblemLM.cpp
@@ -388,13 +388,13 @@ bool RegProblemLM::isValidPatch(
       patchCentreCoord(1) < (wy-1)/2 ||
       patchCentreCoord(1) > camSysPtr_->cam_left_ptr_->height_ - (wy-1)/2 - 1)
     return false;
-  if(mask(patchCentreCoord(1)-(wy-1)/2, patchCentreCoord(0)-(wx-1)/2) < 125)
+  if(mask(static_cast<int>(patchCentreCoord(1)-(wy-1)/2), static_cast<int>(patchCentreCoord(0)-(wx-1)/2)) < 125)
     return false;
-  if(mask(patchCentreCoord(1)-(wy-1)/2, patchCentreCoord(0)+(wx-1)/2) < 125)
+  if(mask(static_cast<int>(patchCentreCoord(1)-(wy-1)/2), static_cast<int>(patchCentreCoord(0)+(wx-1)/2)) < 125)
     return false;
-  if(mask(patchCentreCoord(1)+(wy-1)/2, patchCentreCoord(0)-(wx-1)/2) < 125)
+  if(mask(static_cast<int>(patchCentreCoord(1)+(wy-1)/2), static_cast<int>(patchCentreCoord(0)-(wx-1)/2)) < 125)
     return false;
-  if(mask(patchCentreCoord(1)+(wy-1)/2, patchCentreCoord(0)+(wx-1)/2) < 125)
+  if(mask(static_cast<int>(patchCentreCoord(1)+(wy-1)/2), static_cast<int>(patchCentreCoord(0)+(wx-1)/2)) < 125)
     return false;
   return true;
 }


### PR DESCRIPTION
**Problem**

Eigen 3.4.0 no longer supports floating-point indices. This PR addresses compilation and compile errors caused by using floating-point indices in the project.

**Solution**

* All matrix indices have been changed from floating-point to integer types.
* Key changes:
  * Replaced `float` type indices with `int` type.
  * Adjusted input parameter types of related functions.

**Testing**

Tested on Ubuntu 20.04, ROS Noetic, and Eigen 3.4.0. 

**Additional notes**

Please note that this change may affect old code that uses floating-point indices. It is recommended to carefully review and update related code after upgrading the Eigen version.

Welcome to provide suggestions and improvements.